### PR TITLE
Fix to work with multitenancy

### DIFF
--- a/lib/health-data-standards/models/cqm/measure.rb
+++ b/lib/health-data-standards/models/cqm/measure.rb
@@ -87,7 +87,7 @@ module HealthDataStandards
         pipeline << {'$project' => {'category' => '$_id', 'measures' => 1, '_id' => 0}}
 
         pipeline << {'$sort' => {"category" => 1}}
-        Mongoid.default_session.command(aggregate: 'measures', pipeline: pipeline)['result']
+        mongo_session.command(aggregate: 'measures', pipeline: pipeline)['result']
       end
 
 


### PR DESCRIPTION
This shouldn't change any behavior. When adding multitenancy, the database
will change, and Mongoid's default_session does not actually always use the
default database. Instead we can just use the mongo_session from the Measure
model itself, which should always be correct.
